### PR TITLE
Avoid crash with infinity chests

### DIFF
--- a/variables-manager.lua
+++ b/variables-manager.lua
@@ -86,7 +86,7 @@ function mgr.getFilterVariables(e)
     eType = e.type
   end
 
-  if e.filter_slot_count > 0 then
+  if e.filter_slot_count > 0 and eType ~= 'infinity-container' then    
     for i=1,e.filter_slot_count do
       table.insert(results, getVariable(e.get_filter(i)));
     end


### PR DESCRIPTION
Infinity chests are a bit odd, having filters yet not being a logistic entity.

Follows example of https://github.com/MESLewis/FilterHelper/commit/167ec1215e1430a2727b9d689cf71b15a2cafe04.

Fixes #4.
