### PR TITLE
Support for all locomotive types

### DIFF
--- a/variables-manager.lua
+++ b/variables-manager.lua
@@ -41,7 +41,9 @@ end
 function mgr.getTrainVariables(eArr)
   local results = {}
   for eKey, e in pairs(eArr) do
-    if e.name == 'locomotive' then
+    local eName = e.name 
+    local entity = game.entity_prototypes[eName]
+    if entity.type == 'locomotive' then
       if e.schedule then
         for scheduleKey, schedule in pairs(e.schedule) do
           for w in schedule.station:gmatch("%[.-%]") do


### PR DESCRIPTION
Fetch the prototype of the entity and check that it has type`locomotive`, instead of just checking the name. It allow out of the box support for all different kind of trains, like Space Trains.